### PR TITLE
[WIP] correctly deal with .pcci.yml

### DIFF
--- a/follow_pull_requests.py
+++ b/follow_pull_requests.py
@@ -61,7 +61,7 @@ for repo in repos:
             job['unique_name'] = unique_name
 
             try:
-              pcci_file = yaml.load(g.get_repo(repo).get_contents('.pcci.yml'))
+              pcci_file = yaml.load(g.get_repo(repo).get_contents('.pcci.yml').content)
               os_sets = pcci_file['nodesets']
             except UnknownObjectException,e:
               os_sets = ['trusty','centos7']


### PR DESCRIPTION
This fixes:
```
Traceback (most recent call last):
  File "pcci/follow_pull_requests.py", line 64, in <module>
    pcci_file = yaml.load(g.get_repo(repo).get_contents('.pcci.yml'))
  File "/home/pcci/latest_pygithub/local/lib/python2.7/site-packages/yaml/__init__.py", line 69, in load
    loader = Loader(stream)
  File "/home/pcci/latest_pygithub/local/lib/python2.7/site-packages/yaml/loader.py", line 34, in __init__
    Reader.__init__(self, stream)
  File "/home/pcci/latest_pygithub/local/lib/python2.7/site-packages/yaml/reader.py", line 85, in __init__
    self.determine_encoding()
  File "/home/pcci/latest_pygithub/local/lib/python2.7/site-packages/yaml/reader.py", line 124, in determine_encoding
    self.update_raw()
  File "/home/pcci/latest_pygithub/local/lib/python2.7/site-packages/yaml/reader.py", line 178, in update_raw
    data = self.stream.read(size)
AttributeError: 'ContentFile' object has no attribute 'read'
```

---

remaining error:

```
Traceback (most recent call last):
  File "pcci/follow_pull_requests.py", line 65, in <module>
    os_sets = pcci_file['nodesets']
TypeError: string indices must be integers, not str
```